### PR TITLE
Define worker inline to make it easier to bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For more details and examples, please refer to the [example implementation](http
 Install the service with
 
 ```
-sc.exe create my-test-service binPath= "c:\full\path\to\deno.exe run" --unstable --allow-ffi "C:/path/to/windows-service/example.ts"
+sc.exe create my-test-service binPath= "c:\full\path\to\deno.exe run" --unstable-raw-imports --allow-ffi "C:/path/to/windows-service/example.ts"
 ```
 
 Make sure to adjust the Deno permissions as neccessary.
@@ -54,7 +54,7 @@ Make sure to adjust the Deno permissions as neccessary.
 **Or** compile it using
 
 ```
-deno compile --unstable --allow-ffi example.ts --output my-test-service.exe
+deno compile --unstable-raw-imports --allow-ffi example.ts --output my-test-service.exe
 ```
 
 And install using
@@ -63,7 +63,7 @@ And install using
 sc.exe create my-test-service binPath= "C:/path/to/windows-service/my-test-service.exe"
 ```
 
-> **Note** Both --unstable and --allow-ffi is required at the moment
+> **Note** Both --unstable-raw-imports and --allow-ffi is required at the moment
 
 ## Using `run.ts` as a Generic Service Runner
 
@@ -73,19 +73,19 @@ to run with its arguments after `--`.
 To run the generic service runner with a command:
 
 ```
-deno run --allow-ffi --unstable https://deno.land/x/windows_service/run.ts --serviceName your-service -- your_command your_arguments
+deno run --allow-ffi --unstable-raw-imports https://deno.land/x/windows_service/run.ts --serviceName your-service -- your_command your_arguments
 ```
 
 If you want to debug (execute the command directly without the Windows service part), pass the `--debug` flag:
 
 ```
-deno run --allow-ffi --unstable your_script.ts --serviceName your-service --debug -- your_command your_arguments
+deno run --allow-ffi --unstable-raw-imports your_script.ts --serviceName your-service --debug -- your_command your_arguments
 ```
 
 To install a service using this library and a generic command
 
 ```
-sc.exe create your-service binPath= "c:/full/path/to/deno.exe run --unstable --allow-ffi https://deno.land/x/windows_service/run.ts --serviceName your-service -- your_command your_arguments"
+sc.exe create your-service binPath= "c:/full/path/to/deno.exe run --unstable-raw-imports --allow-ffi https://deno.land/x/windows_service/run.ts --serviceName your-service -- your_command your_arguments"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Make sure to adjust the Deno permissions as neccessary.
 **Or** compile it using
 
 ```
-deno compile --unstable --allow-ffi example.ts --include dispatcher.js --output my-test-service.exe
+deno compile --unstable --allow-ffi example.ts --output my-test-service.exe
 ```
 
 And install using
@@ -62,8 +62,6 @@ And install using
 ```
 sc.exe create my-test-service binPath= "C:/path/to/windows-service/my-test-service.exe"
 ```
-
-Note that dispatcher.ts need to be included using `--include` at compile time, else the service worker wont work.
 
 > **Note** Both --unstable and --allow-ffi is required at the moment
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ deno compile --unstable --allow-ffi example.ts --include dispatcher.js --output 
 And install using
 
 ```
-sc.exe create my-test-service binPath= "C:/path/to/windows-service/my-test-service.ts"
+sc.exe create my-test-service binPath= "C:/path/to/windows-service/my-test-service.exe"
 ```
 
 Note that dispatcher.ts need to be included using `--include` at compile time, else the service worker wont work.


### PR DESCRIPTION
To avoid references between threads and shared state, web workers have to be started from a separate module. This creates a  problem when the application is to be bundled, if the name of the module is given as a literal string: A module must exist with that name and must be available at the same relative location to the calling code.

This can be problematic with `deno compile`: Not just must the dispatcher be available in the work directory to pass to the `--include` option, but in practice the entire library must be vendored for the relative location to stay correct.

This patch attempt to address this problem. Since the dispatcher includes no other modules and in less than 64kiB small, it can be
included as a text resource import and passed to the web worker as an inline data: URL.

Using `--include` is then no longer necessary, and the library can be used as any other. The flag `--unstable-raw-imports` must be used for the time being, but this will probably graduate to stable in the future.