### PR TITLE
Comment how to handle non-ASCII base64 encoding

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -204,6 +204,13 @@ class WindowsService {
     // defined in a separate script, which is a problem for tree-shaking,
     // but we can pass a data: URL with the entire script inline, getting it
     // bundled in our own module.
+	 // If the following line crashes with the error "InvalidCharacterError:
+	 // Cannot encode string: string contains characters outside of the Latin1
+	 // range", there is probably a comment added to the dispatcher with a
+	 // non-ASCII character in it. Consider replacing btoa with the expression
+	 // Buffer.from(dispatcher, 'UTF-8').toBase64() if you have a new enough
+	 // version of Node/Deno. unescape(decodeURIComponent(dispatcher)) has
+	 // been suggested, but apart from being deprecated, won't necessarily work.
     const dispatcherURL = "data:application/javascript;base64," + btoa(dispatcher);
     this.#dispatcherThread = new Worker(dispatcherURL, { type: "module" })
 


### PR DESCRIPTION
From the [comment](https://github.com/Hexagon/windows-service/pull/3#discussion_r2603403642) by Copilot in #3 : 
> Consider using a UTF-8-safe base64 encoding approach

If dispatcher.js contains a non-ASCII character, even just in a comment, the btoa function will throw an error. It has been suggested to use unescape(decodeURIComponent()) but this solution doesn't fix the problem: For example it still raises an error for the expression:

    unescape(decodeURIComponent("let Блюм = 'їжа';"))

A better solution would have been to go through an Uint8Array, in the form of:

    Buffer.from(dispatcher, 'UTF-8').toBase64()

This, however, works only in newer versions of Node and Deno, as the toBase64 function was only recently added.

Since the dispatcher.js currently does not contain any problematic characters, I have just added a comment about what could be done in case this turns into a problem, not putting more requirement onto the runtime than necessary.